### PR TITLE
:package: Resolve `symfony/error-handler` and PHP 8.1 deprecations

### DIFF
--- a/src/CodeTool/ElasticSearch/DSL/Query/ElasticSearchDSLFetchSourceContext.php
+++ b/src/CodeTool/ElasticSearch/DSL/Query/ElasticSearchDSLFetchSourceContext.php
@@ -57,6 +57,10 @@ final class ElasticSearchDSLFetchSourceContext implements ElasticSearchDSLQueryI
         return $this;
     }
 
+    /**
+     * @return bool|array
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         if (false === $this->fetchSource) {

--- a/src/CodeTool/ElasticSearch/ElasticSearchScript.php
+++ b/src/CodeTool/ElasticSearch/ElasticSearchScript.php
@@ -49,6 +49,10 @@ class ElasticSearchScript implements ElasticSearchQueryInterface
         return $this;
     }
 
+    /**
+     * @return string|array
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         if ('' === $this->type && '' === $this->lang && [] === $this->params) {


### PR DESCRIPTION
…about future changes with return types (PHP 9)

> PHP message: PHP Deprecated:  Return type of CodeTool\ElasticSearch\ElasticSearchScript::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/code-tool/es-dsl-lb/src/CodeTool/ElasticSearch/ElasticSearchScript.php on line 52

> PHP message: PHP Deprecated:  Return type of CodeTool\ElasticSearch\DSL\Query\ElasticSearchDSLFetchSourceContext::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/code-tool/es-dsl-lb/src/CodeTool/ElasticSearch/DSL/Query/ElasticSearchDSLFetchSourceContext.php on line 60